### PR TITLE
fix: enable TypeScript tree-sitter parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Enable the TypeScript tree-sitter AST path with the
+  `tree_sitter_typescript.language_typescript()` API and emit warnings when
+  parser initialization falls back to regex. The tree-sitter core dependency
+  now uses the compatible 0.24 line, and the AST path preserves detection of
+  `new Function()` and imported `exec` / `spawn` calls.
+
 ## [0.19.2] - 2026-07-03
 
 ### Fixed

--- a/packages/audit/agent_audit/parsers/treesitter_parser.py
+++ b/packages/audit/agent_audit/parsers/treesitter_parser.py
@@ -188,7 +188,6 @@ class TreeSitterParser:
                 return
 
             # Language packages expose different accessor APIs.
-            wrap_language = False
             if hasattr(parser_module, 'LANGUAGE'):
                 lang = parser_module.LANGUAGE
             elif hasattr(parser_module, 'language'):
@@ -198,7 +197,6 @@ class TreeSitterParser:
                 and hasattr(parser_module, 'language_typescript')
             ):
                 lang = parser_module.language_typescript()
-                wrap_language = True
             else:
                 logger.warning(
                     "tree-sitter language module for %s does not expose a known "
@@ -207,7 +205,7 @@ class TreeSitterParser:
                 )
                 return
 
-            if wrap_language and not isinstance(lang, tree_sitter.Language):
+            if not isinstance(lang, tree_sitter.Language):
                 lang = tree_sitter.Language(lang)
 
             parser = tree_sitter.Parser(lang)

--- a/packages/audit/agent_audit/parsers/treesitter_parser.py
+++ b/packages/audit/agent_audit/parsers/treesitter_parser.py
@@ -187,13 +187,28 @@ class TreeSitterParser:
             if parser_module is None:
                 return
 
-            # tree-sitter-python 0.23+ uses LANGUAGE attribute
+            # Language packages expose different accessor APIs.
+            wrap_language = False
             if hasattr(parser_module, 'LANGUAGE'):
                 lang = parser_module.LANGUAGE
             elif hasattr(parser_module, 'language'):
                 lang = parser_module.language()
+            elif (
+                self.language == 'typescript'
+                and hasattr(parser_module, 'language_typescript')
+            ):
+                lang = parser_module.language_typescript()
+                wrap_language = True
             else:
+                logger.warning(
+                    "tree-sitter language module for %s does not expose a known "
+                    "language accessor; using regex fallback",
+                    self.language,
+                )
                 return
+
+            if wrap_language and not isinstance(lang, tree_sitter.Language):
+                lang = tree_sitter.Language(lang)
 
             parser = tree_sitter.Parser(lang)
             self._tree = parser.parse(self.source.encode('utf-8'))
@@ -201,7 +216,7 @@ class TreeSitterParser:
             logger.debug(f"Using tree-sitter for {self.language}")
 
         except Exception as e:
-            logger.debug(f"tree-sitter init failed: {e}, using regex fallback")
+            logger.warning(f"tree-sitter init failed: {e}, using regex fallback")
             self._use_tree_sitter = False
 
     @property
@@ -435,8 +450,11 @@ class TreeSitterParser:
 
     def _walk_js_calls(self, node: Any, calls: List[FunctionCall]) -> None:
         """Walk JS/TS AST for function calls."""
-        if node.type == 'call_expression':
-            func_node = node.child_by_field_name('function')
+        if node.type in ('call_expression', 'new_expression'):
+            func_node = (
+                node.child_by_field_name('function')
+                or node.child_by_field_name('constructor')
+            )
             args_node = node.child_by_field_name('arguments')
 
             if func_node:

--- a/packages/audit/agent_audit/scanners/typescript_scanner.py
+++ b/packages/audit/agent_audit/scanners/typescript_scanner.py
@@ -63,6 +63,10 @@ TS_DANGEROUS_CALLS: Dict[str, Tuple[str, str, float]] = {
     "child_process.execSync": ("AGENT-034", "ts_child_process_exec", 0.90),
     "child_process.spawn": ("AGENT-034", "ts_child_process_exec", 0.85),
     "child_process.spawnSync": ("AGENT-034", "ts_child_process_exec", 0.85),
+    "exec": ("AGENT-034", "ts_child_process_exec", 0.90),
+    "execSync": ("AGENT-034", "ts_child_process_exec", 0.90),
+    "spawn": ("AGENT-034", "ts_child_process_exec", 0.85),
+    "spawnSync": ("AGENT-034", "ts_child_process_exec", 0.85),
     "execa": ("AGENT-034", "ts_child_process_exec", 0.85),
     "execaSync": ("AGENT-034", "ts_child_process_exec", 0.85),
     # SQL (only when template string used - checked separately)

--- a/packages/audit/pyproject.toml
+++ b/packages/audit/pyproject.toml
@@ -45,7 +45,7 @@ aiohttp = "^3.9"
 aiofiles = "^23.0"
 
 # Optional tree-sitter dependencies for enhanced multi-language parsing
-tree-sitter = {version = "^0.22.0", optional = true}
+tree-sitter = {version = "^0.24.0", optional = true}
 tree-sitter-python = {version = "^0.23.0", optional = true}
 tree-sitter-javascript = {version = "^0.23.0", optional = true}
 tree-sitter-typescript = {version = "^0.23.0", optional = true}

--- a/tests/test_parsers/test_treesitter_parser.py
+++ b/tests/test_parsers/test_treesitter_parser.py
@@ -80,6 +80,61 @@ class TestTreeSitterParser:
 
         assert parser.is_tree_sitter_available
 
+    @pytest.mark.parametrize(
+        ("language", "module_name", "source"),
+        [
+            ("python", "_tree_sitter_python", "value = input"),
+            ("javascript", "_tree_sitter_javascript", "const value = input;"),
+        ],
+    )
+    def test_standard_language_accessor_wraps_capsule(
+        self,
+        monkeypatch,
+        language,
+        module_name,
+        source,
+    ):
+        """Standard language() accessors may return tree-sitter capsules."""
+        capsule = object()
+
+        class FakeLanguage:
+            def __init__(self, value):
+                assert value is capsule
+
+        class FakeParser:
+            def __init__(self, wrapped_language):
+                assert isinstance(wrapped_language, FakeLanguage)
+
+            def parse(self, encoded_source):
+                assert encoded_source == source.encode("utf-8")
+                return object()
+
+        class FakeLanguageModule:
+            @staticmethod
+            def language():
+                return capsule
+
+        class FakeTreeSitter:
+            Language = FakeLanguage
+            Parser = FakeParser
+
+        monkeypatch.setattr(treesitter_parser, "_TREE_SITTER_AVAILABLE", True)
+        monkeypatch.setattr(
+            treesitter_parser,
+            module_name,
+            FakeLanguageModule(),
+        )
+        monkeypatch.setattr(
+            treesitter_parser,
+            "tree_sitter",
+            FakeTreeSitter,
+            raising=False,
+        )
+
+        parser = TreeSitterParser(source, language=language)
+
+        assert parser.is_tree_sitter_available
+
     def test_unknown_language_accessor_warns_and_falls_back(self, monkeypatch, caplog):
         """Unsupported language module APIs should produce a visible warning."""
         monkeypatch.setattr(treesitter_parser, "_TREE_SITTER_AVAILABLE", True)

--- a/tests/test_parsers/test_treesitter_parser.py
+++ b/tests/test_parsers/test_treesitter_parser.py
@@ -1,12 +1,10 @@
 """Tests for tree-sitter parser module."""
 
 import pytest
+import agent_audit.parsers.treesitter_parser as treesitter_parser
 from agent_audit.parsers.treesitter_parser import (
     TreeSitterParser,
     ValueType,
-    Assignment,
-    FunctionCall,
-    StringLiteral,
 )
 
 
@@ -36,6 +34,97 @@ class TestTreeSitterParser:
         """Test default language is Python when not specified."""
         parser = TreeSitterParser("x = 1")
         assert parser.language == 'python'
+
+    def test_typescript_language_accessor_activates_tree_sitter(self, monkeypatch):
+        """TypeScript modules exposing language_typescript() should initialize."""
+        capsule = object()
+
+        class FakeLanguage:
+            def __init__(self, value):
+                assert value is capsule
+
+        class FakeParser:
+            def __init__(self, language):
+                assert isinstance(language, FakeLanguage)
+
+            def parse(self, source):
+                assert source == b"const value: string = input;"
+                return object()
+
+        class FakeTypeScriptModule:
+            @staticmethod
+            def language_typescript():
+                return capsule
+
+        class FakeTreeSitter:
+            Language = FakeLanguage
+            Parser = FakeParser
+
+        monkeypatch.setattr(treesitter_parser, "_TREE_SITTER_AVAILABLE", True)
+        monkeypatch.setattr(
+            treesitter_parser,
+            "_tree_sitter_typescript",
+            FakeTypeScriptModule(),
+        )
+        monkeypatch.setattr(
+            treesitter_parser,
+            "tree_sitter",
+            FakeTreeSitter,
+            raising=False,
+        )
+
+        parser = TreeSitterParser(
+            "const value: string = input;",
+            language="typescript",
+        )
+
+        assert parser.is_tree_sitter_available
+
+    def test_unknown_language_accessor_warns_and_falls_back(self, monkeypatch, caplog):
+        """Unsupported language module APIs should produce a visible warning."""
+        monkeypatch.setattr(treesitter_parser, "_TREE_SITTER_AVAILABLE", True)
+        monkeypatch.setattr(treesitter_parser, "_tree_sitter_typescript", object())
+
+        with caplog.at_level("WARNING"):
+            parser = TreeSitterParser("const value = input;", language="typescript")
+
+        assert not parser.is_tree_sitter_available
+        assert "does not expose a known language accessor" in caplog.text
+
+    def test_tree_sitter_init_failure_warns_and_falls_back(self, monkeypatch, caplog):
+        """Initialization errors should be visible while preserving fallback."""
+        class FakeLanguage:
+            pass
+
+        class FakeParser:
+            def __init__(self, language):
+                raise RuntimeError("parser unavailable")
+
+        class FakeJavaScriptModule:
+            LANGUAGE = FakeLanguage()
+
+        class FakeTreeSitter:
+            Language = FakeLanguage
+            Parser = FakeParser
+
+        monkeypatch.setattr(treesitter_parser, "_TREE_SITTER_AVAILABLE", True)
+        monkeypatch.setattr(
+            treesitter_parser,
+            "_tree_sitter_javascript",
+            FakeJavaScriptModule(),
+        )
+        monkeypatch.setattr(
+            treesitter_parser,
+            "tree_sitter",
+            FakeTreeSitter,
+            raising=False,
+        )
+
+        with caplog.at_level("WARNING"):
+            parser = TreeSitterParser("const value = input;", language="javascript")
+
+        assert not parser.is_tree_sitter_available
+        assert "parser unavailable" in caplog.text
 
 
 class TestPythonAssignments:


### PR DESCRIPTION
## Summary

- recognize `tree_sitter_typescript.language_typescript()` and convert its capsule to a `tree_sitter.Language`
- move the optional core dependency to the compatible `tree-sitter 0.24.x` line
- warn when an unknown accessor or initialization failure forces regex fallback
- preserve the regex path's existing `new Function()` and imported `exec` / `spawn` detections when the TypeScript AST path is active

## Root cause

`tree_sitter_typescript 0.23.x` exposes `language_typescript()` rather than `LANGUAGE` or `language()`. It returns a `PyCapsule`, which also requires `tree-sitter 0.24.x` for `Language(capsule)` conversion; the previous `tree-sitter ^0.22.0` constraint could not initialize that grammar.

## Testing

- `1516 passed, 1 skipped` with all tree-sitter grammar packages installed
- `ruff check packages/audit`
- `ruff check tests/test_parsers/test_treesitter_parser.py tests/test_typescript_scanner.py`
- `mypy packages/audit/agent_audit --ignore-missing-imports` (`81 source files`)
- package-extra smoke test installed `agent-audit[tree-sitter]`, resolved `tree-sitter 0.24.0` / `tree-sitter-typescript 0.23.2`, and asserted `TreeSitterParser(..., file_path="x.ts").is_tree_sitter_available`

## Scope

`.tsx` remains mapped to the TypeScript grammar, matching the current language mapping and the issue's requested minimal scope. Selecting the separate TSX grammar remains a follow-up design decision.

Closes #12.

## AI assistance

This contribution was implemented and tested with OpenAI Codex assistance. The final diff and verification results were reviewed before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript/JavaScript detection for shell execution when `exec*`/`spawn*` are used without `child_process.` qualification, plus better handling of `new Function()`.
  * Added clearer warnings when TypeScript tree-sitter initialization falls back to regex parsing.
  * Enhanced compatibility with TypeScript tree-sitter language accessor variations.
* **Documentation**
  * Updated the changelog with an **[Unreleased] → Fixed** entry describing the TypeScript scanning behavior improvements.
* **Tests**
  * Expanded tree-sitter parser tests to cover TypeScript language accessor handling, UTF-8 parsing input, and warning/fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->